### PR TITLE
Rely on Carpentries' sandpaper translations

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -82,7 +82,7 @@ profiles:
 # This space below is where custom yaml items (e.g. pinning
 # sandpaper and varnish versions) should live
 varnish: epiverse-trace/varnish@tracelactheme
-
-sandpaper: 'epiverse-trace/sandpaper#1'
+# this is carpentries/sandpaper#533 in our fork so we can keep it up to date with main
+sandpaper: epiverse-trace/sandpaper@patch-renv-github-bug
 lang: es
 


### PR DESCRIPTION
The Carpentries now provide the Spanish translation out of the box so we no longer have to provide our own, ensure it's up to date, etc.

This PR now install sandpaper from a simpler branch that only include the fix to install packages from GitHub.
