### PR TITLE
Use same theme as epitkit

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@
 # lc: Library Carpentry
 # cp: Carpentries (to use for instructor training for instance)
 # incubator: The Carpentries Incubator
-carpentry: 'incubator'
+carpentry: 'epitkit'
 
 # Overall title for pages.
 title: 'Análisis de Brotes y Modelamiento en Salud Pública'
@@ -81,7 +81,7 @@ profiles:
 #
 # This space below is where custom yaml items (e.g. pinning
 # sandpaper and varnish versions) should live
-varnish: epiverse-trace/varnish@tracelactheme
+varnish: epiverse-trace/varnish@epiversetheme
 # this is carpentries/sandpaper#533 in our fork so we can keep it up to date with main
 sandpaper: epiverse-trace/sandpaper@patch-renv-github-bug
 lang: es


### PR DESCRIPTION
Does this make sense @Joskerus or do you prefer to keep this branded as a specific event?

The idea of moving to the epitkit theme is to ensure this material is still seen as valuable in 2025, which may be hindered by the "2023" mention on the logo.